### PR TITLE
Be server scheduler

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "concurrently": "^9.1.1",
+    "cron": "^3.3.1",
     "html2canvas": "^1.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -14,7 +16,9 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "concurrently \"npm run bestart\" \"npm run festart\" ",
+    "festart": "react-scripts start",
+    "bestart": "node test_server/index.js",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/src/App.js
+++ b/src/App.js
@@ -18,16 +18,20 @@ function App() {
     useEffect(() => {
         const fetchImage = async () => {
             try {
-                const response = await fetch('http://localhost:3001/images');
-                const data = await response.json();
-                if (response.ok) {
+                const responseImg = await fetch('http://localhost:3001/static/downloaded_image.jpg');
+                const responseTime = await fetch('http://localhost:3001/getLastGetImagineTime');
+                const data = await responseTime.json();
+                if (responseImg.ok) {
                     setImageUrl(`http://localhost:3001/static/downloaded_image.jpg?timestamp=${new Date().getTime()}`);
-                    setImageUpdatedTime(data.timestamp); // 서버에서 받은 시간으로 설정
+                    setImageUpdatedTime(data?.timestamp??'No Time data'); // 서버에서 받은 시간으로 설정
                 } else {
                     console.error('이미지를 가져오는 데 실패했습니다.');
+                    setImageUpdatedTime('No CCTV data');
                 }
             } catch (error) {
+                setImageUpdatedTime('No Time data');
                 console.error('이미지를 가져오는 중 오류가 발생했습니다:', error);
+                
             }
         };
 


### PR DESCRIPTION
기존 :  FE 에서 /images url 을 호출할 때마다 701서버의 이미지를 가져와서 저장함.

변경 : BE 가 실행되면, 스케쥴러가 실행되며, 오전 7시~오후 5시 내에서 5초마다 701서버의 이미지를 가져와서 저장함. 

FE 에서는 간단하게 images url 을 호출하던 로직만 삭제하고, BE서버의 특정 위치에 이미지 파일이 존재하는지 여부만 체크하도록 임시로 변경하였습니다. 